### PR TITLE
timer memory leak bug fix

### DIFF
--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -683,9 +683,13 @@ public class JCVideoPlayer extends FrameLayout implements View.OnClickListener, 
     public static void releaseAllVideos() {
         if (!isClickFullscreen) {
             JCMediaManager.intance().mediaPlayer.stop();
+            JCMediaManager.intance().mediaPlayer = null;
             JCMediaManager.intance().setUuid("");
             JCMediaManager.intance().setUuid("");
             EventBus.getDefault().post(new VideoEvents().setType(VideoEvents.VE_MEDIAPLAYER_FINISH_COMPLETE));
+            if (mUpdateProgressTimer != null) {
+                mUpdateProgressTimer.cancel();
+            }
         }
     }
 


### PR DESCRIPTION
i've added a few line of code that cancel mUpdateProgressTimer when releaseAllVideo method is calling.