### PR TITLE
Avoid JCMediaPlayerListener strong references

### DIFF
--- a/app/src/main/java/fm/jiecao/jiecaovideoplayer/View/JCVideoPlayerStandardFresco.java
+++ b/app/src/main/java/fm/jiecao/jiecaovideoplayer/View/JCVideoPlayerStandardFresco.java
@@ -15,7 +15,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import fm.jiecao.jcvideoplayer_lib.JCBuriedPointStandard;
-import fm.jiecao.jcvideoplayer_lib.JCMediaManager;
 import fm.jiecao.jcvideoplayer_lib.JCVideoPlayer;
 import fm.jiecao.jiecaovideoplayer.R;
 
@@ -129,7 +128,7 @@ public class JCVideoPlayerStandardFresco extends JCVideoPlayer {
         startDismissControlViewTimer();
       }
     } else if (i == R.id.surface_container) {
-      if (jc_BuriedPointStandard != null && JCMediaManager.instance().listener == this) {
+      if (jc_BuriedPointStandard != null && isCurrentMediaListener()) {
         if (mIfCurrentIsFullscreen) {
           jc_BuriedPointStandard.onClickBlankFullscreen(mUrl, mObjects);
         } else {

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCFullScreenActivity.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCFullScreenActivity.java
@@ -86,7 +86,7 @@ public class JCFullScreenActivity extends Activity {
       mJcVideoPlayer.startButton.performClick();
     } else {
       JCVideoPlayer.IF_RELEASE_WHEN_ON_PAUSE = true;
-      JCMediaManager.instance().listener = mJcVideoPlayer;
+      JCMediaManager.instance().setListener(mJcVideoPlayer);
     }
   }
 

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
@@ -9,6 +9,7 @@ import android.os.Message;
 import android.text.TextUtils;
 import android.view.Surface;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -21,17 +22,45 @@ import java.util.Map;
  * On 2015/11/30 15:39
  */
 public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener,
-  MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnSeekCompleteListener, MediaPlayer.OnErrorListener,
-  MediaPlayer.OnVideoSizeChangedListener, MediaPlayer.OnInfoListener {
+        MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnSeekCompleteListener, MediaPlayer.OnErrorListener,
+        MediaPlayer.OnVideoSizeChangedListener, MediaPlayer.OnInfoListener {
   public static String TAG = JCVideoPlayer.TAG;
 
   public MediaPlayer mediaPlayer;
   private static JCMediaManager JCMediaManager;
   public int currentVideoWidth = 0;
   public int currentVideoHeight = 0;
-  public JCMediaPlayerListener listener;
-  public JCMediaPlayerListener lastListener;
+  private WeakReference<JCMediaPlayerListener> listener;
+  private WeakReference<JCMediaPlayerListener> lastListener;
   public int lastState;
+
+  public JCMediaPlayerListener listener() {
+    if(listener == null)
+      return null;
+
+    return listener.get();
+  }
+
+  public JCMediaPlayerListener lastListener() {
+    if(listener == null)
+      return null;
+
+    return lastListener.get();
+  }
+
+  public void setListener(JCMediaPlayerListener listener) {
+    if (listener == null)
+      this.listener = null;
+    else
+      this.listener = new WeakReference<>(listener);
+  }
+
+  public void setLastListener(JCMediaPlayerListener lastListener) {
+    if (lastListener == null)
+      this.lastListener = null;
+    else
+      this.lastListener = new WeakReference<>(lastListener);
+  }
 
   public static final int HANDLER_PREPARE = 0;
   public static final int HANDLER_SETDISPLAY = 1;
@@ -140,8 +169,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onPrepared();
+        if (listener() != null) {
+          listener().onPrepared();
         }
       }
     });
@@ -152,8 +181,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onAutoCompletion();
+        if (listener() != null) {
+          listener().onAutoCompletion();
         }
       }
     });
@@ -164,8 +193,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onBufferingUpdate(percent);
+        if (listener() != null) {
+          listener().onBufferingUpdate(percent);
         }
       }
     });
@@ -176,8 +205,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onSeekComplete();
+        if (listener() != null) {
+          listener().onSeekComplete();
         }
       }
     });
@@ -188,8 +217,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onError(what, extra);
+        if (listener() != null) {
+          listener().onError(what, extra);
         }
       }
     });
@@ -201,8 +230,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onInfo(what, extra);
+        if (listener() != null) {
+          listener().onInfo(what, extra);
         }
       }
     });
@@ -216,8 +245,8 @@ public class JCMediaManager implements MediaPlayer.OnPreparedListener, MediaPlay
     mainThreadHandler.post(new Runnable() {
       @Override
       public void run() {
-        if (listener != null) {
-          listener.onVideoSizeChanged();
+        if (listener() != null) {
+          listener().onVideoSizeChanged();
         }
       }
     });

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -139,8 +139,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
   }
 
   public boolean setUp(String url, Object... objects) {
-    if (JCMediaManager.instance().listener == this &&
-      (System.currentTimeMillis() - CLICK_QUIT_FULLSCREEN_TIME) < FULL_SCREEN_NORMAL_DELAY)
+    if (isCurrentMediaListener() &&
+            (System.currentTimeMillis() - CLICK_QUIT_FULLSCREEN_TIME) < FULL_SCREEN_NORMAL_DELAY)
       return false;
     mCurrentState = CURRENT_STATE_NORMAL;
     this.mUrl = url;
@@ -167,7 +167,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
     mCurrentState = state;
     switch (mCurrentState) {
       case CURRENT_STATE_NORMAL:
-        if (JCMediaManager.instance().listener == this) {
+        if (isCurrentMediaListener()) {
           cancelProgressTimer();
           JCMediaManager.instance().releaseMediaPlayer();
         }
@@ -182,7 +182,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
         startProgressTimer();
         break;
       case CURRENT_STATE_ERROR:
-        if (JCMediaManager.instance().listener == this) {
+        if (isCurrentMediaListener()) {
           onCompletion();
           JCMediaManager.instance().releaseMediaPlayer();
         }
@@ -196,6 +196,11 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
 //        }
         break;
     }
+  }
+
+  protected boolean isCurrentMediaListener() {
+    return JCMediaManager.instance().listener() != null
+            && JCMediaManager.instance().listener() == this;
   }
 
   @Override
@@ -232,7 +237,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
         Log.d(TAG, "pauseVideo [" + this.hashCode() + "] ");
         JCMediaManager.instance().mediaPlayer.pause();
         setStateAndUi(CURRENT_STATE_PAUSE);
-        if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+        if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
           if (mIfCurrentIsFullscreen) {
             JC_BURIED_POINT.onClickStopFullscreen(mUrl, mObjects);
           } else {
@@ -240,7 +245,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
           }
         }
       } else if (mCurrentState == CURRENT_STATE_PAUSE) {
-        if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+        if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
           if (mIfCurrentIsFullscreen) {
             JC_BURIED_POINT.onClickResumeFullscreen(mUrl, mObjects);
           } else {
@@ -259,13 +264,13 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
         backFullscreen();
       } else {
         Log.d(TAG, "toFullscreenActivity [" + this.hashCode() + "] ");
-        if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+        if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
           JC_BURIED_POINT.onEnterFullscreen(mUrl, mObjects);
         }
         //to fullscreen
         JCMediaManager.instance().setDisplay(null);
-        JCMediaManager.instance().lastListener = this;
-        JCMediaManager.instance().listener = null;
+        JCMediaManager.instance().setLastListener(this);
+        JCMediaManager.instance().setListener(null);
         IF_FULLSCREEN_FROM_NORMAL = true;
         IF_RELEASE_WHEN_ON_PAUSE = false;
         JCFullScreenActivity.startActivityFromNormal(getContext(), mCurrentState, mUrl, JCVideoPlayer.this.getClass(), this.mObjects);
@@ -289,10 +294,10 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
 
   protected void prepareVideo() {
     Log.d(TAG, "prepareVideo [" + this.hashCode() + "] ");
-    if (JCMediaManager.instance().listener != null) {
-      JCMediaManager.instance().listener.onCompletion();
+    if (JCMediaManager.instance().listener() != null) {
+      JCMediaManager.instance().listener().onCompletion();
     }
-    JCMediaManager.instance().listener = this;
+    JCMediaManager.instance().setListener(this);
     addSurfaceView();
     AudioManager mAudioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
     mAudioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
@@ -386,13 +391,13 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
                 if (absDeltaX >= mThreshold) {
                   mChangePosition = true;
                   mDownPosition = getCurrentPositionWhenPlaying();
-                  if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+                  if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
                     JC_BURIED_POINT.onTouchScreenSeekPosition(mUrl, mObjects);
                   }
                 } else {
                   mChangeVolume = true;
                   mDownVolume = mAudioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
-                  if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+                  if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
                     JC_BURIED_POINT.onTouchScreenSeekVolume(mUrl, mObjects);
                   }
                 }
@@ -423,7 +428,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
           }
           /////////////////////
           startProgressTimer();
-          if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+          if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
             if (mIfCurrentIsFullscreen) {
               JC_BURIED_POINT.onClickSeekbarFullscreen(mUrl, mObjects);
             } else {
@@ -518,7 +523,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
   @Override
   public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
     if (mCurrentState != CURRENT_STATE_PLAYING &&
-      mCurrentState != CURRENT_STATE_PAUSE) return;
+            mCurrentState != CURRENT_STATE_PAUSE) return;
     if (fromUser) {
       int time = progress * getDuration() / 100;
       JCMediaManager.instance().mediaPlayer.seekTo(time);
@@ -547,7 +552,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
   @Override
   public void onAutoCompletion() {
     //make me normal first
-    if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+    if (JC_BURIED_POINT != null
+            && isCurrentMediaListener()) {
       if (mIfCurrentIsFullscreen) {
         JC_BURIED_POINT.onAutoCompleteFullscreen(mUrl, mObjects);
       } else {
@@ -561,9 +567,9 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
     finishFullscreenActivity();
     if (IF_FULLSCREEN_FROM_NORMAL) {//如果在进入全屏后播放完就初始化自己非全屏的控件
       IF_FULLSCREEN_FROM_NORMAL = false;
-      JCMediaManager.instance().lastListener.onAutoCompletion();
+      JCMediaManager.instance().lastListener().onAutoCompletion();
     }
-    JCMediaManager.instance().lastListener = null;
+    JCMediaManager.instance().setLastListener(null);
     AudioManager mAudioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
     mAudioManager.abandonAudioFocus(onAudioFocusChangeListener);
     ((Activity) getContext()).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -581,10 +587,10 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
 
     if (IF_FULLSCREEN_FROM_NORMAL) {//如果在进入全屏后播放完就初始化自己非全屏的控件
       IF_FULLSCREEN_FROM_NORMAL = false;
-      JCMediaManager.instance().lastListener.onCompletion();
+      JCMediaManager.instance().lastListener().onCompletion();
     }
-    JCMediaManager.instance().listener = null;
-    JCMediaManager.instance().lastListener = null;
+    JCMediaManager.instance().setListener(null);
+    JCMediaManager.instance().setLastListener(null);
     JCMediaManager.instance().currentVideoWidth = 0;
     JCMediaManager.instance().currentVideoHeight = 0;
 
@@ -721,14 +727,14 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
 
   protected void quitFullScreenGoToNormal() {
     Log.i(TAG, "quitFullScreenGoToNormal [" + this.hashCode() + "] ");
-    if (JC_BURIED_POINT != null && JCMediaManager.instance().listener == this) {
+    if (JC_BURIED_POINT != null && isCurrentMediaListener()) {
       JC_BURIED_POINT.onQuitFullscreen(mUrl, mObjects);
     }
     JCMediaManager.instance().setDisplay(null);
-    JCMediaManager.instance().listener = JCMediaManager.instance().lastListener;
-    JCMediaManager.instance().lastListener = null;
+    JCMediaManager.instance().setListener(JCMediaManager.instance().lastListener());
+    JCMediaManager.instance().setLastListener(null);
     JCMediaManager.instance().lastState = mCurrentState;//save state
-    JCMediaManager.instance().listener.onBackFullscreen();
+    JCMediaManager.instance().listener().onBackFullscreen();
     finishFullscreenActivity();
   }
 
@@ -755,8 +761,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
   public static void releaseAllVideos() {
     if (IF_RELEASE_WHEN_ON_PAUSE) {
       Log.i(TAG, "releaseAllVideos");
-      if (JCMediaManager.instance().listener != null) {
-        JCMediaManager.instance().listener.onCompletion();
+      if (JCMediaManager.instance().listener() != null) {
+        JCMediaManager.instance().listener().onCompletion();
       }
       JCMediaManager.instance().releaseMediaPlayer();
     } else {
@@ -768,9 +774,9 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
    * if I am playing release me
    */
   public void release() {
-    if (JCMediaManager.instance().listener == this &&
+    if (isCurrentMediaListener() &&
 //      mCurrentState != CURRENT_STATE_NORMAL &&
-      (System.currentTimeMillis() - CLICK_QUIT_FULLSCREEN_TIME) > FULL_SCREEN_NORMAL_DELAY) {
+            (System.currentTimeMillis() - CLICK_QUIT_FULLSCREEN_TIME) > FULL_SCREEN_NORMAL_DELAY) {
       Log.i(TAG, "release [" + this.hashCode() + "]");
       releaseAllVideos();
     }

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayerStandard.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayerStandard.java
@@ -174,7 +174,7 @@ public class JCVideoPlayerStandard extends JCVideoPlayer {
         onClickUiToggle();
       }
     } else if (i == R.id.surface_container) {
-      if (JC_BURIED_POINT_STANDARD != null && JCMediaManager.instance().listener == this) {
+      if (JC_BURIED_POINT_STANDARD != null && isCurrentMediaListener()) {
         if (mIfCurrentIsFullscreen) {
           JC_BURIED_POINT_STANDARD.onClickBlankFullscreen(mUrl, mObjects);
         } else {


### PR DESCRIPTION
JCMediaPlayerListener instances in JCMediaManager held strong references, which was causing memory leaks

Fixes https://github.com/lipangit/JieCaoVideoPlayer/issues/110