### PR TITLE
解决窗口和全屏切换时缓冲进度丢失的问题

### DIFF
--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
@@ -34,6 +34,7 @@ public class JCMediaManager implements IMediaPlayer.OnPreparedListener, IMediaPl
     public int currentVideoWidth  = 0;
     public int currentVideoHeight = 0;
     public int lastState;
+    public int bufferPercent;
 
     public static final int HANDLER_PREPARE    = 0;
     public static final int HANDLER_SETDISPLAY = 1;

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
@@ -35,6 +35,7 @@ public class JCMediaManager implements IMediaPlayer.OnPreparedListener, IMediaPl
     public int currentVideoHeight = 0;
     public int lastState;
     public int bufferPercent;
+    public int backUpBufferState = -1;
 
     public static final int HANDLER_PREPARE    = 0;
     public static final int HANDLER_SETDISPLAY = 1;

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -93,7 +93,6 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
     protected AudioManager      mAudioManager;
     protected Handler           mHandler;
     protected ProgressTimerTask mProgressTimerTask;
-    protected int mBackUpBufferState = -1;
 
     protected boolean mTouchingProgressBar;
     protected float   mDownX;
@@ -505,13 +504,13 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
     public void onInfo(int what, int extra) {
         Log.d(TAG, "onInfo what - " + what + " extra - " + extra);
         if (what == MediaPlayer.MEDIA_INFO_BUFFERING_START) {
-            mBackUpBufferState = currentState;
+            JCMediaManager.instance().backUpBufferState = currentState;
             setUiWitStateAndScreen(CURRENT_STATE_PLAYING_BUFFERING_START);
             Log.d(TAG, "MEDIA_INFO_BUFFERING_START");
         } else if (what == MediaPlayer.MEDIA_INFO_BUFFERING_END) {
-            if (mBackUpBufferState != -1) {
-                setUiWitStateAndScreen(mBackUpBufferState);
-                mBackUpBufferState = -1;
+            if (JCMediaManager.instance().backUpBufferState != -1) {
+                setUiWitStateAndScreen(JCMediaManager.instance().backUpBufferState);
+                JCMediaManager.instance().backUpBufferState = -1;
             }
             Log.d(TAG, "MEDIA_INFO_BUFFERING_END");
         }

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -216,6 +216,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
 
         JCUtils.scanForActivity(getContext()).getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         JCMediaManager.instance().prepare(url, mapHeadData, looping);
+        JCMediaManager.instance().bufferPercent = 0;
         setUiWitStateAndScreen(CURRENT_STATE_PREPAREING);
     }
 
@@ -326,9 +327,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
                 resetProgressAndTime();
                 break;
             case CURRENT_STATE_PLAYING:
-                startProgressTimer();
-                break;
             case CURRENT_STATE_PAUSE:
+            case CURRENT_STATE_PLAYING_BUFFERING_START:
                 startProgressTimer();
                 break;
             case CURRENT_STATE_ERROR:
@@ -485,6 +485,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
         if (currentState != CURRENT_STATE_NORMAL && currentState != CURRENT_STATE_PREPAREING) {
             Log.v(TAG, "onBufferingUpdate " + percent + " [" + this.hashCode() + "] ");
             setTextAndProgress(percent);
+            JCMediaManager.instance().bufferPercent = percent;
         }
     }
 
@@ -686,7 +687,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
                 mHandler.post(new Runnable() {
                     @Override
                     public void run() {
-                        setTextAndProgress(0);
+                        setTextAndProgress(JCMediaManager.instance().bufferPercent);
                     }
                 });
             }


### PR DESCRIPTION
解决缓冲状态下从窗口模式切换到全屏模式导致全屏模式下的播放进度丢失问题。

解决在播放、暂停、缓冲状态下，从窗口模式切换到全屏模式导致缓冲进度丢失问题。