### PR TITLE
Fix ProgressTimerTask memory leak by making it static.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '24.0.2'
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         applicationId "fm.jiecao.jiecaovideoplayer"

--- a/jcvideoplayer-lib/build.gradle
+++ b/jcvideoplayer-lib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '24.0.2'
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
Add annotations to ints to be used as ids

Upgrade to tools 24.0.3

Fixes https://github.com/lipangit/JieCaoVideoPlayer/issues/533