### PR TITLE
Move JCMediaManger.textureView to WeakReference to avoid context leak

### DIFF
--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
@@ -60,7 +60,7 @@ public class JCMediaManager implements ExoPlayer.EventListener, SimpleExoPlayer.
     void createTextureView(Context context){
         JCResizeTextureView textureView = new JCResizeTextureView(context);
         textureView.setVideoSize(getVideoSize());
-        textureView.setRotation(videoRotation);
+        textureView.setSurfaceTextureListener(this);
         weakTextureView = new WeakReference<>(textureView);
     }
 
@@ -273,9 +273,11 @@ public class JCMediaManager implements ExoPlayer.EventListener, SimpleExoPlayer.
         Log.i(TAG, "onSurfaceTextureAvailable [" + this.hashCode() + "] ");
         if (savedSurfaceTexture == null) {
             savedSurfaceTexture = surfaceTexture;
-            prepare(textureView.getContext(), CURRENT_PLAYING_URL, null, false);
+            if(textureView() != null)
+                prepare(textureView().getContext(), CURRENT_PLAYING_URL, null, false);
         } else {
-            textureView.setSurfaceTexture(savedSurfaceTexture);
+            if(textureView() != null)
+                textureView().setSurfaceTexture(savedSurfaceTexture);
         }
     }
 

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCMediaManager.java
@@ -8,6 +8,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Surface;
@@ -36,6 +37,7 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 
+import java.lang.ref.WeakReference;
 import java.util.Map;
 
 /**
@@ -49,11 +51,26 @@ public class JCMediaManager implements ExoPlayer.EventListener, SimpleExoPlayer.
 
     public static String USER_AGENT = "android_jcvd";
     private static JCMediaManager JCMediaManager;
-    public static JCResizeTextureView textureView;
     public static SurfaceTexture savedSurfaceTexture;
     public SimpleExoPlayer simpleExoPlayer;
     public static String CURRENT_PLAYING_URL;
 
+    private WeakReference<JCResizeTextureView> weakTextureView;
+
+    void createTextureView(Context context){
+        JCResizeTextureView textureView = new JCResizeTextureView(context);
+        textureView.setVideoSize(getVideoSize());
+        textureView.setRotation(videoRotation);
+        weakTextureView = new WeakReference<>(textureView);
+    }
+
+    @Nullable
+    JCResizeTextureView textureView(){
+        if(weakTextureView == null)
+            return null;
+
+        return weakTextureView.get();
+    }
 
     public int currentVideoWidth = 0;
     public int currentVideoHeight = 0;

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -326,9 +326,6 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
     public void initTextureView() {
         removeTextureView();
         JCMediaManager.instance().createTextureView(getContext());
-        if(JCMediaManager.instance().textureView() != null) {
-          JCMediaManager.instance().textureView().setSurfaceTextureListener(this);
-		}
     }
 
     public void addTextureView() {        
@@ -443,7 +440,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
 //            JCMediaManager.instance().releaseMediaPlayer();
 //        }
         // 清理缓存变量
-        textureViewContainer.removeView(JCMediaManager.textureView);
+        removeTextureView();
         JCMediaManager.instance().currentVideoWidth = 0;
         JCMediaManager.instance().currentVideoHeight = 0;
 
@@ -467,7 +464,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
 //                final Animation ra = AnimationUtils.loadAnimation(getContext(), R.anim.quit_fullscreen);
 //                startAnimation(ra);
 //            }
-            textureViewContainer.removeView(JCMediaManager.textureView);
+            removeTextureView();
             ViewGroup vp = (ViewGroup) (JCUtils.scanForActivity(getContext()))//.getWindow().getDecorView();
                     .findViewById(Window.ID_ANDROID_CONTENT);
             vp.removeView(this);
@@ -635,7 +632,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
         if (old != null) {
             vp.removeView(old);
         }
-        textureViewContainer.removeView(JCMediaManager.textureView);
+        removeTextureView();
         try {
             Constructor<JCVideoPlayer> constructor = (Constructor<JCVideoPlayer>) JCVideoPlayer.this.getClass().getConstructor(Context.class);
             JCVideoPlayer jcVideoPlayer = constructor.newInstance(getContext());
@@ -666,7 +663,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
         if (old != null) {
             vp.removeView(old);
         }
-        textureViewContainer.removeView(JCMediaManager.textureView);
+        removeTextureView();
 
         try {
             Constructor<JCVideoPlayer> constructor = (Constructor<JCVideoPlayer>) JCVideoPlayer.this.getClass().getConstructor(Context.class);

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -325,24 +325,28 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
 
     public void initTextureView() {
         removeTextureView();
-        JCMediaManager.textureView = new JCResizeTextureView(getContext());
-        JCMediaManager.textureView.setSurfaceTextureListener(JCMediaManager.instance());
+        JCMediaManager.instance().createTextureView(getContext());
+        if(JCMediaManager.instance().textureView() != null) {
+          JCMediaManager.instance().textureView().setSurfaceTextureListener(this);
+		}
     }
 
-    public void addTextureView() {
+    public void addTextureView() {        
+        if(JCMediaManager.instance().textureView() != null) {
         Log.d(TAG, "addTextureView [" + this.hashCode() + "] ");
         FrameLayout.LayoutParams layoutParams =
                 new FrameLayout.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         Gravity.CENTER);
-        textureViewContainer.addView(JCMediaManager.textureView, layoutParams);
+        textureViewContainer.addView(JCMediaManager.instance().textureView(), layoutParams);
+        }
     }
 
     public void removeTextureView() {
         JCMediaManager.savedSurfaceTexture = null;
-        if (JCMediaManager.textureView != null && JCMediaManager.textureView.getParent() != null) {
-            ((ViewGroup) JCMediaManager.textureView.getParent()).removeView(JCMediaManager.textureView);
+        if (JCMediaManager.instance().textureView() != null && JCMediaManager.instance().textureView().getParent() != null) {
+            ((ViewGroup) JCMediaManager.instance().textureView().getParent()).removeView(JCMediaManager.instance().textureView());
         }
     }
 
@@ -574,7 +578,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements JCMediaPlayer
     @Override
     public void onVideoSizeChanged() {
         Log.i(TAG, "onVideoSizeChanged " + " [" + this.hashCode() + "] ");
-        JCMediaManager.textureView.setVideoSize(JCMediaManager.instance().getVideoSize());
+        if(JCMediaManager.instance().textureView() != null) {
+          JCMediaManager.instance().textureView().setVideoSize(JCMediaManager.instance().getVideoSize());        }
     }
 
     @Override


### PR DESCRIPTION
Delegate TextureView creation to JCMediaPlayer

Fixes https://github.com/lipangit/JieCaoVideoPlayer/issues/536

I've tested the demo app and everything seems to work fine.

I've also tested the *.aar* in my app and the leak has gone away