### PR TITLE
fix:ProgressTimerTask导致内存泄露

### DIFF
--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -484,6 +484,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
 
         JCMediaManager.textureView = null;
         JCMediaManager.savedSurfaceTexture = null;
+        cancelProgressTimer();
 //        JCMediaManager.textureView = null;
     }
 
@@ -817,6 +818,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
         if ((System.currentTimeMillis() - CLICK_QUIT_FULLSCREEN_TIME) > FULL_SCREEN_NORMAL_DELAY) {
             Log.d(TAG, "releaseAllVideos");
             JCVideoPlayerManager.completeAll();
+            JCVideoPlayerManager.releaseFullscreenVideos();
             JCMediaManager.instance().releaseMediaPlayer();
         }
     }
@@ -852,6 +854,7 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
             jcVideoPlayer.setUp(url, JCVideoPlayerStandard.SCREEN_WINDOW_FULLSCREEN, objects);
             CLICK_QUIT_FULLSCREEN_TIME = System.currentTimeMillis();
             jcVideoPlayer.startButton.performClick();
+            JCVideoPlayerManager.setFullscreenJcvd(jcVideoPlayer);
         } catch (InstantiationException e) {
             e.printStackTrace();
         } catch (Exception e) {
@@ -941,6 +944,5 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
     }
 
     public abstract int getLayoutId();
-
 
 }

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayerManager.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayerManager.java
@@ -1,5 +1,7 @@
 package fm.jiecao.jcvideoplayer_lib;
 
+import android.util.Log;
+
 /**
  * Put JCVideoPlayer into layout
  * From a JCVideoPlayer to another JCVideoPlayer
@@ -9,6 +11,16 @@ public class JCVideoPlayerManager {
 
     public static JCVideoPlayer FIRST_FLOOR_JCVD;
     public static JCVideoPlayer SECOND_FLOOR_JCVD;
+    public static JCVideoPlayer FULLSCREEN_JCVD;
+
+
+    public static JCVideoPlayer getFullscreenJcvd() {
+        return FULLSCREEN_JCVD;
+    }
+
+    public static void setFullscreenJcvd(JCVideoPlayer fullscreenJcvd) {
+        FULLSCREEN_JCVD = fullscreenJcvd;
+    }
 
     public static void setFirstFloor(JCVideoPlayer jcVideoPlayer) {
         FIRST_FLOOR_JCVD = jcVideoPlayer;
@@ -41,6 +53,13 @@ public class JCVideoPlayerManager {
         if (FIRST_FLOOR_JCVD != null) {
             FIRST_FLOOR_JCVD.onCompletion();
             FIRST_FLOOR_JCVD = null;
+        }
+    }
+
+    public static void releaseFullscreenVideos(){
+        if (FULLSCREEN_JCVD != null) {
+            FULLSCREEN_JCVD.onCompletion();
+            FULLSCREEN_JCVD = null;
         }
     }
 }


### PR DESCRIPTION
利用JcVideoPlayerManager回调了JCVideoPlayer的onCompletion 并在onCompletion中调用cancelProgressTimer()方法