### PR TITLE
小修改，解决某些默认横屏的app切换全屏播放后切回来变竖屏的问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
+++ b/jcvideoplayer-lib/src/main/java/fm/jiecao/jcvideoplayer_lib/JCVideoPlayer.java
@@ -136,6 +136,8 @@ public abstract class JCVideoPlayer extends FrameLayout implements View.OnClickL
         mScreenHeight = getContext().getResources().getDisplayMetrics().heightPixels;
         mAudioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
         mHandler = new Handler();
+
+        NORMAL_ORIENTATION = context.getResources().getConfiguration().orientation;
     }
 
     public void setUp(String url, int screen, Object... objects) {


### PR DESCRIPTION
可能是因为一般对手机的印象是竖持，所以没有被发现过？
这个问题多现于平板上的app开发，这种东西因为屏幕比和大小，有些时候app需求（当然也可能是程序猴子偷懒不想做支持）会在manifest里锁横屏，这时候就会有切全屏的问题，切完再回来会发现竖过去了。
看了一下和NORMAL_ORIENTATION打个架就行，除了默认给它个初始值，init时再获取一次定义值应该更合理。