### PR TITLE
BugFix:  修复ScrollView中使用小窗在惯性滑动时crash的问题，issue: #1801 & issue #1577

### DIFF
--- a/app/src/main/java/cn/jzvd/demo/ActivityTinyWindow.java
+++ b/app/src/main/java/cn/jzvd/demo/ActivityTinyWindow.java
@@ -3,10 +3,14 @@ package cn.jzvd.demo;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.widget.NestedScrollView;
 import android.support.v7.app.AppCompatActivity;
+import android.util.DisplayMetrics;
+import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.FrameLayout;
 
 import com.bumptech.glide.Glide;
 
@@ -49,7 +53,39 @@ public class ActivityTinyWindow extends AppCompatActivity implements View.OnClic
         mBtnTinyWindowListViewMultiHolder.setOnClickListener(this);
         mBtnTinyWindowRecycle.setOnClickListener(this);
         mBtnTinyWindowRecycleMultiHolder.setOnClickListener(this);
+        makeTinyWindowInScrollView();
+    }
 
+    private void makeTinyWindowInScrollView() {
+        setWindowTinyLayoutParams();
+        NestedScrollView scrollView = findViewById(R.id.scrollView);
+        NestedScrollView.OnScrollChangeListener listener = new NestedScrollView.OnScrollChangeListener() {
+            boolean videoIsShown;
+            @Override
+            public void onScrollChange(NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                boolean display = scrollY >= mJzVideoPlayerStandard.getHeight();
+                if (this.videoIsShown ^ display) {
+                    this.videoIsShown = display;
+                    if (display) {
+                        JZVideoPlayer.onChildViewDetachedFromWindow((View) mJzVideoPlayerStandard.getParent());
+                    } else {
+                        JZVideoPlayer.onChildViewAttachedToWindow(mJzVideoPlayerStandard);
+                    }
+                }
+            }
+        };
+        scrollView.setOnScrollChangeListener(listener);
+    }
+
+    private void setWindowTinyLayoutParams() {
+        DisplayMetrics metrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        int screenWidth = metrics.widthPixels;
+        int height = screenWidth * 9 / 16;
+        FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(screenWidth >> 1, height >> 1);
+        layoutParams.gravity = Gravity.CENTER_VERTICAL | Gravity.END;
+        layoutParams.rightMargin = 20;
+        mJzVideoPlayerStandard.setWindowTinyLayoutParams(layoutParams);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_tiny_window.xml
+++ b/app/src/main/res/layout/activity_tiny_window.xml
@@ -4,7 +4,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <ScrollView
+    <android.support.v4.widget.NestedScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:scrollbars="none">
@@ -58,7 +59,12 @@
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="8dp"
                 android:text="RecycleView MultiHolder TinyWindow" />
-
+            <!-- make ScrollView scrollable -->
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="400dp"
+                android:background="#F2F2F2"
+                />
         </LinearLayout>
-    </ScrollView>
+    </android.support.v4.widget.NestedScrollView>
 </LinearLayout>

--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
@@ -840,10 +840,10 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
     public void clearFloatScreen() {
         JZUtils.setRequestedOrientation(getContext(), NORMAL_ORIENTATION);
         showSupportActionBar(getContext());
-        ViewGroup vp = (JZUtils.scanForActivity(getContext()))//.getWindow().getDecorView();
+        final ViewGroup vp = (JZUtils.scanForActivity(getContext()))//.getWindow().getDecorView();
                 .findViewById(Window.ID_ANDROID_CONTENT);
         JZVideoPlayer fullJzvd = vp.findViewById(R.id.jz_fullscreen_id);
-        JZVideoPlayer tinyJzvd = vp.findViewById(R.id.jz_tiny_id);
+        final JZVideoPlayer tinyJzvd = vp.findViewById(R.id.jz_tiny_id);
 
         if (fullJzvd != null) {
             vp.removeView(fullJzvd);
@@ -851,7 +851,12 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
                 fullJzvd.textureViewContainer.removeView(JZMediaManager.textureView);
         }
         if (tinyJzvd != null) {
-            vp.removeView(tinyJzvd);
+            post(new Runnable() {
+                @Override
+                public void run() {
+                    vp.removeView(tinyJzvd);
+                }
+            });
             if (tinyJzvd.textureViewContainer != null)
                 tinyJzvd.textureViewContainer.removeView(JZMediaManager.textureView);
         }

--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
@@ -326,6 +326,37 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
             }
         }
     }
+    public static void onChildViewAttachedToWindow(JZVideoPlayer videoPlayer) {
+        if (JZVideoPlayerManager.getCurrentJzvd() != null && JZVideoPlayerManager.getCurrentJzvd().currentScreen == JZVideoPlayer.SCREEN_WINDOW_TINY) {
+            if (videoPlayer != null && JZUtils.getCurrentFromDataSource(videoPlayer.dataSourceObjects, videoPlayer.currentUrlMapIndex).equals(JZMediaManager.getCurrentDataSource())) {
+                JZVideoPlayer.backPress();
+            }
+        }
+    }
+
+    public static void onChildViewAttachedToWindow(View view) {
+        JZVideoPlayer jzVideoPlayer = findJzVideoPlayer(view);
+        if (jzVideoPlayer != null) {
+            onChildViewAttachedToWindow(jzVideoPlayer);
+        }
+    }
+
+    private static JZVideoPlayer findJzVideoPlayer(View view) {
+        if (view instanceof JZVideoPlayer) {
+            return (JZVideoPlayer) view;
+        }
+        if (view instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) view;
+            int childCount = viewGroup.getChildCount();
+            for (int i = 0; i < childCount; i++) {
+                JZVideoPlayer videoPlayer = findJzVideoPlayer(viewGroup.getChildAt(i));
+                if (videoPlayer != null) {
+                    return videoPlayer;
+                }
+            }
+        }
+        return null;
+    }
 
     public static void onChildViewDetachedFromWindow(View view) {
         if (JZVideoPlayerManager.getCurrentJzvd() != null && JZVideoPlayerManager.getCurrentJzvd().currentScreen != JZVideoPlayer.SCREEN_WINDOW_TINY) {

--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
@@ -127,6 +127,7 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
     protected float mGestureDownBrightness;
     protected long mSeekTimePosition;
     boolean tmp_test_back = false;
+    private LayoutParams windowTinyLayoutParams;
 
     public JZVideoPlayer(Context context) {
         super(context);
@@ -1024,9 +1025,11 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
             Constructor<JZVideoPlayer> constructor = (Constructor<JZVideoPlayer>) JZVideoPlayer.this.getClass().getConstructor(Context.class);
             JZVideoPlayer jzVideoPlayer = constructor.newInstance(getContext());
             jzVideoPlayer.setId(R.id.jz_tiny_id);
-            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(400, 400);
-            lp.gravity = Gravity.RIGHT | Gravity.BOTTOM;
-            vp.addView(jzVideoPlayer, lp);
+            if (windowTinyLayoutParams == null) {
+                windowTinyLayoutParams = new FrameLayout.LayoutParams(400, 400);
+                windowTinyLayoutParams.gravity = Gravity.RIGHT | Gravity.BOTTOM;
+            }
+            vp.addView(jzVideoPlayer, windowTinyLayoutParams);
             jzVideoPlayer.setUp(dataSourceObjects, currentUrlMapIndex, JZVideoPlayerStandard.SCREEN_WINDOW_TINY, objects);
             jzVideoPlayer.setState(currentState);
             jzVideoPlayer.addTextureView();
@@ -1038,6 +1041,15 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
             e.printStackTrace();
         }
     }
+
+    public void setWindowTinyLayoutParams(LayoutParams layoutParams) {
+        this.windowTinyLayoutParams = layoutParams;
+    }
+
+    public LayoutParams setWindowTinyLayoutParans() {
+        return windowTinyLayoutParams;
+    }
+
 
     public boolean isCurrentPlay() {
         return isCurrentJZVD()


### PR DESCRIPTION
1. 修复ScrollView中使用小窗在惯性滑动时crash的问题: issue [#1801](https://github.com/lipangit/JiaoZiVideoPlayer/issues/1801) & [#1577](https://github.com/lipangit/JiaoZiVideoPlayer/issues/1577)
2. 新增setWindowTinyLayoutParams方法，方便自定义小窗播放时的布局
3. 新增onChildViewAttachedToWindow重载方法，方便在ScrollView中以及在JZVideoPlayer未设置id或id未知的情况下使用小窗功能
4. 在demo中新增演示了自定义小窗布局及在ScrollView中使用小窗的功能：[ActivityTinyWindow.java](https://github.com/luckybilly/JiaoZiVideoPlayer/blob/develop/app/src/main/java/cn/jzvd/demo/ActivityTinyWindow.java)